### PR TITLE
Fixes bug where the only points involved in computePointAtDistanceThreshold

### DIFF
--- a/config-example.yml
+++ b/config-example.yml
@@ -92,7 +92,7 @@ graphhopper:
   # More are: surface,smoothness,max_width,max_height,max_weight,max_weight_except,hgv,max_axle_load,max_length,
   #           hazmat,hazmat_tunnel,hazmat_water,lanes,osm_way_id,toll,track_type,mtb_rating,hike_rating,horse_rating,
   #           country,curvature,average_slope,max_slope,car_temporal_access,bike_temporal_access,foot_temporal_access
-  graph.encoded_values: car_access, car_average_speed
+  graph.encoded_values: car_access, car_average_speed, road_access
 
   #### Speed, hybrid and flexible mode ####
 

--- a/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
@@ -488,14 +488,14 @@ public class BufferResource {
         // only contain TOWER points and not PILLAR points.
         // When this happens, filtering by FetchMode.PILLAR_ONLY will return an empty
         // PointList.
-        if (pointList.size() == 0) {
-            return new PointList();
+        if (pointList.isEmpty()) {
+            return pointList;
         }
 
         // When the buffer is only as wide as a single edge, truncate one half of the
         // segment
         if (startFeature.getEdge().equals(endFeature.getEdge())) {
-            return new PointList();
+            return pointList;
         }
 
         // Reverse geometry when starting at adjacent node

--- a/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
@@ -495,7 +495,7 @@ public class BufferResource {
         // When the buffer is only as wide as a single edge, truncate one half of the
         // segment
         if (startFeature.getEdge().equals(endFeature.getEdge())) {
-            return pointList;
+            return new PointList();
         }
 
         // Reverse geometry when starting at adjacent node

--- a/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
@@ -484,6 +484,14 @@ public class BufferResource {
         EdgeIteratorState finalState = graph.getEdgeIteratorState(endFeature.getEdge(), Integer.MIN_VALUE);
         PointList pointList = finalState.fetchWayGeometry(FetchMode.PILLAR_ONLY);
 
+        // It is possible that the finalState.fetchWayGeometry(FetchMode.xxxx) would
+        // only contain TOWER points and not PILLAR points.
+        // When this happens, filtering by FetchMode.PILLAR_ONLY will return an empty
+        // PointList.
+        if (pointList.size() == 0) {
+            return new PointList();
+        }
+
         // When the buffer is only as wide as a single edge, truncate one half of the
         // segment
         if (startFeature.getEdge().equals(endFeature.getEdge())) {


### PR DESCRIPTION
It can happen that both the starting point and the ending point that get passed to computePointAtDistanceThreshold are points in intersections rather than points BETWEEN intersections.  When this happens, computePointAtDistanceThreshold will fail because the method does two things:
1. Filters out any intersection points from the results at this line:
_PointList pointList = finalState.fetchWayGeometry(FetchMode.PILLAR_ONLY);_
2. attempts this if-block.  If it enters this if-block then it tries pointList.reverse() (which cannot handle an empty PointList)
_// Reverse geometry when starting at adjacent node
        if (upstreamPath && finalState.getAdjNode() == endFeature.getNode() || !upstreamPath && finalState.getAdjNode() == endFeature.getNode()) {
            pointList.reverse();
        }_

You can test that this is what is happening by replacing computePointAtDistanceThreshold with this logging-added modified computePointAtDistanceThreshold below and testing it on the north-carolina-latest.osm.pbf with 
http://localhost:8989/buffer?point=35.1771105,-80.875977&roadName=South Boulevard&thresholdDistance=1609&buildUpstream=true

Note that the modified method shown below in this 'description' does NOT include the bug fix because it is desirable for the code to fail so that it displays the logging immediately before the failure.
-----------------------------------------------------------------------------
    private PointList computePointAtDistanceThreshold(BufferFeature startFeature, Double thresholdDistance,
                                                      BufferFeature endFeature, Boolean upstreamPath) {
        EdgeIteratorState finalState = graph.getEdgeIteratorState(endFeature.getEdge(), Integer.MIN_VALUE);
        PointList pointList = finalState.fetchWayGeometry(FetchMode.PILLAR_ONLY);

        PointList mdoPointList = finalState.fetchWayGeometry(FetchMode.ALL);
        List<GHPoint3D> towerPoints = new ArrayList<>();
        if (mdoPointList.size() != pointList.size()) {
            boolean isTowerPoint = true;
            for (GHPoint3D mdoPoint : mdoPointList) {
                for (GHPoint3D point : pointList) {
                    if (point.getLat() == mdoPoint.getLat() && point.getLon() == mdoPoint.getLon()) {
                        isTowerPoint = false;
                        break;
                    }

                }
                if (isTowerPoint) {
                    towerPoints.add(mdoPoint);
                }
            }
            if (towerPoints.size() > 0) {
                StringBuilder builder = new StringBuilder();
                for (GHPoint3D towerPoint : towerPoints) {
                    builder.append("\t" + towerPoint.getLat() + " " + towerPoint.getLon());
                }
                System.out.println("Number of pillar points: " + pointList.size() + "\tTower points: " + builder);
            }
        }

        // When the buffer is only as wide as a single edge, truncate one half of the
        // segment
        if (startFeature.getEdge().equals(endFeature.getEdge())) {
            return new PointList();
        }

        // Reverse geometry when starting at adjacent node
        if (upstreamPath && finalState.getAdjNode() == endFeature.getNode() || !upstreamPath && finalState.getAdjNode() == endFeature.getNode()) {
            pointList.reverse();
        }

        Double currentDistance = endFeature.getDistance();
        GHPoint3D previousPoint = pointList.get(0);

        return computePathListWithinThreshold(thresholdDistance, pointList, currentDistance, previousPoint);
    }