### PR TITLE
Fix Dead End Bug when Threshold Not Met

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
@@ -323,7 +323,7 @@ public class BufferResource {
      */
     private BufferFeature computeEdgeAtDistanceThreshold(final BufferFeature startFeature, Double thresholdDistance,
                                                          String roadName, Boolean upstreamPath, Boolean upstreamStart) {
-        List<Integer> usedEdges = new ArrayList<Integer>() {
+        List<Integer> usedEdges = new ArrayList<>() {
             {
                 add(startFeature.getEdge());
             }

--- a/web/src/test/java/com/graphhopper/application/resources/BufferResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/BufferResourceTest.java
@@ -31,14 +31,14 @@ public class BufferResourceTest {
     private static GraphHopperServerConfiguration createConfig() {
         GraphHopperServerConfiguration config = new GraphHopperServerTestConfiguration();
         config.getGraphHopperConfiguration()
-                .putObject("datareader.file", "../core/files/andorra.osm.pbf")
-                .putObject("import.osm.ignored_highways", "")
-                .putObject("graph.location", DIR)
-                .putObject("graph.encoded_values", "car_access, car_average_speed")
-                .setProfiles(Arrays.asList(
-                        TestProfiles.accessAndSpeed("fast_car", "car").setTurnCostsConfig(TurnCostsConfig.car()),
-                        TestProfiles.constantSpeed("short_car", 35).setTurnCostsConfig(TurnCostsConfig.car()),
-                        TestProfiles.accessAndSpeed("fast_car_no_turn_restrictions", "car")));
+            .putObject("datareader.file", "../core/files/andorra.osm.pbf")
+            .putObject("import.osm.ignored_highways", "")
+            .putObject("graph.location", DIR)
+            .putObject("graph.encoded_values", "car_access, car_average_speed")
+            .setProfiles(Arrays.asList(
+                TestProfiles.accessAndSpeed("fast_car", "car").setTurnCostsConfig(TurnCostsConfig.car()),
+                TestProfiles.constantSpeed("short_car", 35).setTurnCostsConfig(TurnCostsConfig.car()),
+                TestProfiles.accessAndSpeed("fast_car_no_turn_restrictions", "car")));
         return config;
     }
 


### PR DESCRIPTION
**Summary**

Currently, we are running into a dead-end issue when trying to create a buffer for NC Ver-Mac data. The reason is that they are providing us with "River St" but at one end, the street is renamed to W Main St. The buffer is requesting a mile upstream but we haven't met the criteria so we return a dead-end exception.

**Solution**

Rather than throwing an error, we return the path up to the point of failure. We have not met the threshold yet but we can return the path generated instead of throwing an error.

**Notes**

Once the PR has been approved, we will need to generate a new tar file so we can import it on the SDX Graphhopper repository to include the updated buffer resource.