### PR TITLE
Reduced Road Name Requirements in BufferResource

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
@@ -316,7 +316,7 @@ public class BufferResource {
     /**
      * Determines the road name to use based on the provided parameters:
      * - If `roadName` is null:
-     *   - Throws an exception if `requireRoadNameMatch` is true.
+     *   - Throws an exception if `requireRoadNameMatch` is true. (handled in doGet)
      *   - Otherwise, finds the closest edge to the point and uses its road name.
      * - If `roadName` is not null:
      *   - Uses the sanitized road name if `requireRoadNameMatch` is true.

--- a/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
@@ -72,7 +72,7 @@ public class BufferResource {
             throw new IllegalArgumentException("Query multiplier is too high.");
         } else if (queryMultiplier <= 0) {
             throw new IllegalArgumentException("Query multiplier cannot be zero or negative.");
-        } else if (requireRoadNameMatch && roadName == null) {
+        } else if (requireRoadNameMatch && (roadName == null || roadName.isEmpty())) {
             throw new IllegalArgumentException("Road name is required when requireRoadNameMatch is true.");
         }
 

--- a/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
@@ -17,6 +17,7 @@ import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.BBox;
 import com.graphhopper.util.shapes.GHPoint;
 import com.graphhopper.util.shapes.GHPoint3D;
+import org.jetbrains.annotations.Nullable;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
@@ -62,21 +63,24 @@ public class BufferResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Response doGet(
             @QueryParam("point") @NotNull GHPointParam point,
-            @QueryParam("roadName") @NotNull String roadName,
+            @QueryParam("roadName") @Nullable String roadName,
             @QueryParam("thresholdDistance") @NotNull Double thresholdDistance,
-            @QueryParam("queryMultiplier") @DefaultValue(".01") Double queryMultiplier,
-            @QueryParam("buildUpstream") @DefaultValue("false") Boolean buildUpstream) {
+            @QueryParam("queryMultiplier") @DefaultValue(".000075") Double queryMultiplier, // Default of ~8.33 meters in degrees
+            @QueryParam("buildUpstream") @DefaultValue("false") Boolean buildUpstream,
+            @QueryParam("requireRoadNameMatch") @DefaultValue("false") Boolean requireRoadNameMatch) {
         if (queryMultiplier > 1) {
             throw new IllegalArgumentException("Query multiplier is too high.");
         } else if (queryMultiplier <= 0) {
             throw new IllegalArgumentException("Query multiplier cannot be zero or negative.");
+        } else if (requireRoadNameMatch && roadName == null) {
+            throw new IllegalArgumentException("Road name is required when requireRoadNameMatch is true.");
         }
 
         StopWatch sw = new StopWatch().start();
 
-        roadName = sanitizeRoadNames(roadName).get(0);
-        BufferFeature primaryStartFeature = calculatePrimaryStartFeature(point.get().lat, point.get().lon, roadName,
-                queryMultiplier);
+        roadName = getBufferRoadName(roadName, requireRoadNameMatch, point);
+
+        BufferFeature primaryStartFeature = calculatePrimaryStartFeature(point.get().lat, point.get().lon, roadName, queryMultiplier);
         EdgeIteratorState state = graph.getEdgeIteratorState(primaryStartFeature.getEdge(), Integer.MIN_VALUE);
         List<LineString> lineStrings = new ArrayList<>();
 
@@ -106,12 +110,13 @@ public class BufferResource {
      * @param queryMultiplier base dimension of query box
      * @return buffer feature closest to start lat/long
      */
-    private BufferFeature calculatePrimaryStartFeature(Double startLat, Double startLon, String roadName,
-                                                       Double queryMultiplier) {
+    private BufferFeature calculatePrimaryStartFeature(Double startLat, Double startLon, String roadName, Double queryMultiplier) {
         // Scale up query Bbox
         for (int i = 1; i < 4; i++) {
-            BBox bbox = new BBox(startLon - queryMultiplier * i, startLon + queryMultiplier * i,
-                    startLat - queryMultiplier * i, startLat + queryMultiplier * i);
+            BBox bbox = new BBox(
+                    startLon - queryMultiplier * i, startLon + queryMultiplier * i,
+                    startLat - queryMultiplier * i, startLat + queryMultiplier * i
+            );
 
             final List<Integer> filteredQueryEdges = queryBbox(bbox, roadName);
 
@@ -120,7 +125,7 @@ public class BufferResource {
             }
         }
 
-        throw new WebApplicationException("Could not find road with that name near the selection.");
+        throw new WebApplicationException("Could not find primary road with that name near the selection.");
     }
 
     /**
@@ -133,8 +138,7 @@ public class BufferResource {
      * @param queryMultiplier     base dimension of query box
      * @return buffer feature closest to primary start feature
      */
-    private BufferFeature calculateSecondaryStartFeature(BufferFeature primaryStartFeature, String roadName,
-                                                         Double queryMultiplier) {
+    private BufferFeature calculateSecondaryStartFeature(BufferFeature primaryStartFeature, String roadName, Double queryMultiplier) {
         double startLat = primaryStartFeature.getPoint().lat;
         double startLon = primaryStartFeature.getPoint().lon;
 
@@ -165,15 +169,16 @@ public class BufferResource {
             }
         }
 
-        throw new WebApplicationException("Could not find road with that name near the selection.");
+        throw new WebApplicationException("Could not find secondary road with that name near the selection.");
     }
 
     /**
-     * Filters out all edges within a bbox that don't have a matching road name
+     * Filters out all edges within a bbox that don't have a matching road name.
+     * If no road name is provided, filters out all edges that don't have a non-empty road name.
      *
      * @param bbox     query zone
      * @param roadName name of road
-     * @return all edges which have matching road name
+     * @return all edges within the bbox that meet the road name filter requirements
      */
     private List<Integer> queryBbox(BBox bbox, String roadName) {
         final List<Integer> filteredEdgesInBbox = new ArrayList<>();
@@ -181,7 +186,9 @@ public class BufferResource {
         this.locationIndex.query(bbox, edgeId -> {
             EdgeIteratorState state = graph.getEdgeIteratorState(edgeId, Integer.MIN_VALUE);
             List<String> queryRoadNames = getAllRouteNamesFromEdge(state);
-            if (queryRoadNames.stream().anyMatch(x -> x.contains(roadName))) {
+
+            if ((roadName != null && queryRoadNames.stream().anyMatch(x -> x.contains(roadName))) ||
+                    (roadName == null && !queryRoadNames.stream().allMatch(String::isEmpty))) {
                 filteredEdgesInBbox.add(edgeId);
             }
         });
@@ -290,7 +297,6 @@ public class BufferResource {
 
         for (Integer edge : edgeList) {
             EdgeIteratorState state = graph.getEdgeIteratorState(edge, Integer.MIN_VALUE);
-
             PointList pointList = state.fetchWayGeometry(FetchMode.PILLAR_ONLY);
 
             for (GHPoint3D point : pointList) {
@@ -305,6 +311,127 @@ public class BufferResource {
         }
 
         return new BufferFeature(nearestEdge, nearestPoint, 0.0);
+    }
+
+    /**
+     * Determines the road name to use based on the provided parameters:
+     * - If `roadName` is null:
+     *   - Throws an exception if `requireRoadNameMatch` is true.
+     *   - Otherwise, finds the closest edge to the point and uses its road name.
+     * - If `roadName` is not null:
+     *   - Uses the sanitized road name if `requireRoadNameMatch` is true.
+     *   - Otherwise, finds the closest edge with the best matching road name and uses its road name.
+     *
+     * @param roadName              road name
+     * @param requireRoadNameMatch  require road name match
+     * @param point                 point to use for road name matching
+     * @return the road name to use throughout the class
+     */
+    private String getBufferRoadName(String roadName, Boolean requireRoadNameMatch, GHPointParam point) {
+        if (!requireRoadNameMatch) {
+            // Define a small bounding box to reduce the number of edges to filter
+            double twentyFeetInDegrees = 0.0000549;
+            BBox reducedBbox = new BBox(
+                point.get().lon - twentyFeetInDegrees, point.get().lon + twentyFeetInDegrees,
+                point.get().lat - twentyFeetInDegrees, point.get().lat + twentyFeetInDegrees
+            );
+            List<Integer> nearbyEdges = queryBbox(reducedBbox, null);
+
+            String roadNameFromEdge = null;
+            if (!nearbyEdges.isEmpty()) {
+                // Get the best edge based on distance and longest common subsequence with the provided road name (if any)
+                Integer bestEdge = findEdgeByDistAndLCSRoadName(nearbyEdges, point.get().lat, point.get().lon, roadName);
+                EdgeIteratorState state = graph.getEdgeIteratorState(bestEdge, Integer.MIN_VALUE);
+                roadNameFromEdge = getAllRouteNamesFromEdge(state).stream()
+                        .filter(name -> !name.isEmpty())
+                        .findFirst()
+                        .orElse(null);
+            }
+
+            if (roadNameFromEdge == null) {
+                if (roadName == null) {
+                    throw new WebApplicationException("Could not find road name from lat/lon and no road name provided to use as an alternative.");
+                }
+                return sanitizeRoadNames(roadName).get(0);
+            }
+            return roadNameFromEdge;
+        }
+
+        return sanitizeRoadNames(roadName).get(0);
+    }
+
+    /**
+     * Cycles through a list of edges and selects the point which is closest to
+     * the given lat/lon and has the longest common subsequence with the given road name (if provided).
+     *
+     * @param edgeList all nearby edges
+     * @param startLat latitude
+     * @param startLon longitude
+     * @param roadName name of road
+     * @return best matching edge to the given lat/lon considering distance and road name
+     */
+    private Integer findEdgeByDistAndLCSRoadName(List<Integer> edgeList, Double startLat, Double startLon, String roadName) {
+        double lowestDistance = Double.MAX_VALUE;
+        int bestMatchScore = -1;
+        Integer nearestEdge = null;
+
+        for (Integer edge : edgeList) {
+            EdgeIteratorState state = graph.getEdgeIteratorState(edge, Integer.MIN_VALUE);
+            List<String> roadNames = getAllRouteNamesFromEdge(state);
+
+            // Calculate the best match score for this edge
+            int currentMatchScore = 0;
+            if (roadName != null) {
+                for (String edgeRoadName : roadNames) {
+                    currentMatchScore = Math.max(currentMatchScore, calculateLCSLength(roadName, edgeRoadName));
+                }
+            }
+
+            // Calculate the distance to the edge
+            PointList pointList = state.fetchWayGeometry(FetchMode.PILLAR_ONLY);
+            for (GHPoint3D point : pointList) {
+                double dist = DistancePlaneProjection.DIST_PLANE.calcDist(startLat, startLon, point.lat, point.lon);
+
+                // Prioritize the edge with the best match score and the lowest distance
+                if ((currentMatchScore > bestMatchScore) || (currentMatchScore == bestMatchScore && dist < lowestDistance)) {
+                    bestMatchScore = currentMatchScore;
+                    lowestDistance = dist;
+                    nearestEdge = edge;
+                }
+            }
+        }
+
+        return nearestEdge;
+    }
+
+    /**
+     * Calculates the length of the longest common subsequence (LCS) between two strings.
+     * Used when finding the best edge by comparing its road name to the provided road name.
+     *
+     * @param str1 first string
+     * @param str2 second string
+     * @return length of the longest common subsequence
+     */
+    private int calculateLCSLength(String str1, String str2) {
+        // Create a 2D array to store the lengths of longest common subsequences for substrings of str1 and str2
+        int[][] lcsTable = new int[str1.length() + 1][str2.length() + 1];
+
+        // Iterate through each character of both strings
+        for (int i = 1; i <= str1.length(); i++) {
+            for (int j = 1; j <= str2.length(); j++) {
+                // If characters match, increment the length of the LCS by 1
+                if (str1.charAt(i - 1) == str2.charAt(j - 1)) {
+                    lcsTable[i][j] = lcsTable[i - 1][j - 1] + 1;
+                }
+                // Otherwise, take the maximum LCS length from the top or left cell
+                else {
+                    lcsTable[i][j] = Math.max(lcsTable[i - 1][j], lcsTable[i][j - 1]);
+                }
+            }
+        }
+
+        // Return the length of the longest common subsequence
+        return lcsTable[str1.length()][str2.length()];
     }
 
     /**
@@ -334,9 +461,9 @@ public class BufferResource {
         PointList path = new PointList();
 
         // Check starting edge
-        double currentDistance = DistancePlaneProjection.DIST_PLANE.calcDist(startFeature.getPoint().getLat(),
-                startFeature.getPoint().getLon(),
-                nodeAccess.getLat(currentNode), nodeAccess.getLon(currentNode));
+        double currentDistance = DistancePlaneProjection.DIST_PLANE.calcDist(
+            startFeature.getPoint().getLat(), startFeature.getPoint().getLon(),
+            nodeAccess.getLat(currentNode), nodeAccess.getLon(currentNode));
         double previousDistance = 0.0;
         Integer currentEdge = -1;
         // Create previous values to use in case we don't meet the threshold
@@ -372,8 +499,7 @@ public class BufferResource {
                         break;
                     }
 
-                    // Temp has proper road name and isn't part of a roundabout. Lower priority
-                    // escape.
+                    // Temp has proper road name and isn't part of a roundabout. Lower priority escape.
                     else if (roadNames.stream().anyMatch(x -> x.contains(roadName))
                             && !tempState.get(this.roundaboutAccessEnc)) {
                         potentialEdges.add(tempEdge);
@@ -395,12 +521,10 @@ public class BufferResource {
             // No bidirectional edge found. Choose from potential edge lists.
             if (currentEdge == -1) {
                 if (!potentialEdges.isEmpty()) {
-
                     // The Michigan Left
                     if (potentialEdges.size() > 1) {
                         // This logic is not infallible as it stands, but there's no clear alternative.
                         // In the case of a Michigan left, choose the edge that's further away
-
                         EdgeIteratorState tempState = graph.getEdgeIteratorState(potentialEdges.get(0),
                                 Integer.MIN_VALUE);
                         double dist1 = Math.abs(

--- a/web/src/test/java/com/graphhopper/application/resources/BufferResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/BufferResourceTest.java
@@ -1,15 +1,10 @@
 package com.graphhopper.application.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.graphhopper.GraphHopper;
-import com.graphhopper.GraphHopperConfig;
 import com.graphhopper.application.GraphHopperApplication;
 import com.graphhopper.application.GraphHopperServerConfiguration;
 import com.graphhopper.application.util.GraphHopperServerTestConfiguration;
-import com.graphhopper.config.Profile;
-import com.graphhopper.resources.BufferResource;
 import com.graphhopper.routing.TestProfiles;
-import com.graphhopper.util.CustomModel;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.JsonFeatureCollection;
 import com.graphhopper.util.TurnCostsConfig;
@@ -24,7 +19,6 @@ import org.locationtech.jts.geom.Geometry;
 import javax.ws.rs.core.Response;
 import java.io.File;
 import java.util.Arrays;
-import java.lang.reflect.Method;
 
 import static com.graphhopper.application.util.TestUtils.clientTarget;
 import static org.junit.jupiter.api.Assertions.*;

--- a/web/src/test/java/com/graphhopper/application/resources/BufferResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/BufferResourceTest.java
@@ -1,10 +1,15 @@
 package com.graphhopper.application.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.graphhopper.GraphHopper;
+import com.graphhopper.GraphHopperConfig;
 import com.graphhopper.application.GraphHopperApplication;
 import com.graphhopper.application.GraphHopperServerConfiguration;
 import com.graphhopper.application.util.GraphHopperServerTestConfiguration;
+import com.graphhopper.config.Profile;
+import com.graphhopper.resources.BufferResource;
 import com.graphhopper.routing.TestProfiles;
+import com.graphhopper.util.CustomModel;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.JsonFeatureCollection;
 import com.graphhopper.util.TurnCostsConfig;
@@ -19,6 +24,7 @@ import org.locationtech.jts.geom.Geometry;
 import javax.ws.rs.core.Response;
 import java.io.File;
 import java.util.Arrays;
+import java.lang.reflect.Method;
 
 import static com.graphhopper.application.util.TestUtils.clientTarget;
 import static org.junit.jupiter.api.Assertions.*;
@@ -46,6 +52,70 @@ public class BufferResourceTest {
     @AfterAll
     public static void cleanUp() {
         Helper.removeDir(new File(DIR));
+    }
+
+    @Test
+    public void testIllegalArgumentThrownWhenRequireRoadNameMatchIsTrueAndRoadNameIsNull() {
+        JsonNode json;
+        try (Response response = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.54287,1.471&thresholdDistance=2000&requireRoadNameMatch=true").request()
+                .buildGet().invoke()) {
+            assertEquals(400, response.getStatus());
+            json = response.readEntity(JsonNode.class);
+        }
+        assertTrue(json.has("message"), "There should have been an error response");
+        String expected = "Road name is required when requireRoadNameMatch is true.";
+        assertTrue(json.get("message").asText().contains(expected),
+                "There should be an error containing " + expected + ", but got: "
+                        + json.get("message"));
+    }
+
+    @Test
+    public void testIllegalArgumentThrownWhenQueryMultiplierIsTooHigh() {
+        JsonNode json;
+        try (Response response = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.54287,1.471&roadName=CG-4&thresholdDistance=2000&queryMultiplier=2").request()
+                .buildGet().invoke()) {
+            assertEquals(400, response.getStatus());
+            json = response.readEntity(JsonNode.class);
+        }
+        assertTrue(json.has("message"), "There should have been an error response");
+        String expected = "Query multiplier is too high.";
+        assertTrue(json.get("message").asText().contains(expected),
+                "There should be an error containing " + expected + ", but got: "
+                        + json.get("message"));
+    }
+
+    @Test
+    public void testIllegalArgumentThrownWhenQueryMultiplierIsNegative() {
+        JsonNode json;
+        try (Response response = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.54287,1.471&roadName=CG-4&thresholdDistance=2000&queryMultiplier=-1").request()
+                .buildGet().invoke()) {
+            assertEquals(400, response.getStatus());
+            json = response.readEntity(JsonNode.class);
+        }
+        assertTrue(json.has("message"), "There should have been an error response");
+        String expected = "Query multiplier cannot be zero or negative.";
+        assertTrue(json.get("message").asText().contains(expected),
+                "There should be an error containing " + expected + ", but got: "
+                        + json.get("message"));
+    }
+
+    @Test
+    public void testIllegalArgumentThrownWhenQueryMultiplierIsZero() {
+        JsonNode json;
+        try (Response response = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.54287,1.471&roadName=CG-4&thresholdDistance=2000&queryMultiplier=0").request()
+                .buildGet().invoke()) {
+            assertEquals(400, response.getStatus());
+            json = response.readEntity(JsonNode.class);
+        }
+        assertTrue(json.has("message"), "There should have been an error response");
+        String expected = "Query multiplier cannot be zero or negative.";
+        assertTrue(json.get("message").asText().contains(expected),
+                "There should be an error containing " + expected + ", but got: "
+                        + json.get("message"));
     }
 
     @Test
@@ -94,19 +164,105 @@ public class BufferResourceTest {
     }
 
     @Test
-    public void testInvalidRoadName() {
+    public void testInvalidRoadNameFailsWhenRequireRoadMatchIsTrue() {
         JsonNode json;
         try (Response response = clientTarget(app, "/buffer?profile=my_car&"
-                + "point=42.57839,1.631823&roadName=INVALID&thresholdDistance=2000")
+                + "point=42.57839,1.631823&roadName=INVALID&thresholdDistance=2000&requireRoadNameMatch=true")
                 .request().buildGet().invoke()) {
             assertEquals(500, response.getStatus());
             json = response.readEntity(JsonNode.class);
         }
         assertTrue(json.has("message"), "There should have been an error response");
-        String expected = "Could not find road with that name near the selection.";
+        String expected = "Could not find primary road with that name near the selection.";
         assertTrue(json.get("message").asText().contains(expected),
                 "There should be an error containing " + expected + ", but got: "
                         + json.get("message"));
+    }
+
+    @Test
+    public void testInvalidRoadNameSucceedsWhenRequireRoadMatchIsFalse_Bidirectional() {
+        JsonFeatureCollection featureCollection;
+        try (Response response = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.54287,1.471&roadName=INVALID&thresholdDistance=2000&requireRoadNameMatch=false").request()
+                .buildGet().invoke()) {
+            assertEquals(200, response.getStatus());
+
+            featureCollection = response.readEntity(JsonFeatureCollection.class);
+        }
+        assertEquals(2, featureCollection.getFeatures().size());
+        Geometry lineString0 = featureCollection.getFeatures().get(0).getGeometry();
+        Geometry lineString1 = featureCollection.getFeatures().get(1).getGeometry();
+
+        // Identical start points
+        assertEquals(lineString0.getCoordinates()[0], lineString1.getCoordinates()[0]);
+
+        // Different end points
+        assertNotEquals(lineString0.getCoordinates()[lineString0.getCoordinates().length - 1],
+                lineString1.getCoordinates()[lineString1.getCoordinates().length - 1]);
+    }
+
+    @Test
+    public void testNullRoadNameSucceedsWhenRequireRoadMatchIsFalse_Bidirectional() {
+        JsonFeatureCollection featureCollection;
+        try (Response response = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.54287,1.471&thresholdDistance=2000&requireRoadNameMatch=false").request()
+                .buildGet().invoke()) {
+            assertEquals(200, response.getStatus());
+
+            featureCollection = response.readEntity(JsonFeatureCollection.class);
+        }
+        assertEquals(2, featureCollection.getFeatures().size());
+        Geometry lineString0 = featureCollection.getFeatures().get(0).getGeometry();
+        Geometry lineString1 = featureCollection.getFeatures().get(1).getGeometry();
+
+        // Identical start points
+        assertEquals(lineString0.getCoordinates()[0], lineString1.getCoordinates()[0]);
+
+        // Different end points
+        assertNotEquals(lineString0.getCoordinates()[lineString0.getCoordinates().length - 1],
+                lineString1.getCoordinates()[lineString1.getCoordinates().length - 1]);
+    }
+
+    @Test
+    public void testInvalidRoadNameSucceedsWhenRequireRoadMatchIsFalse_Unidirectional() {
+        JsonFeatureCollection featureCollection;
+        try (Response response = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.57839,1.631823&roadName=INVALID&thresholdDistance=2000&requireRoadNameMatch=false").request()
+                .buildGet().invoke()) {
+            assertEquals(200, response.getStatus());
+
+            featureCollection = response.readEntity(JsonFeatureCollection.class);
+        }
+        assertEquals(2, featureCollection.getFeatures().size());
+        Geometry lineString0 = featureCollection.getFeatures().get(0).getGeometry();
+        Geometry lineString1 = featureCollection.getFeatures().get(1).getGeometry();
+
+        // Different start points
+        assertNotEquals(lineString0.getCoordinates()[0], lineString1.getCoordinates()[0]);
+        // Arbitrary - different endpoints
+        assertNotEquals(lineString0.getCoordinates()[lineString0.getCoordinates().length - 1],
+                lineString1.getCoordinates()[lineString1.getCoordinates().length - 1]);
+    }
+
+    @Test
+    public void testNullRoadNameSucceedsWhenRequireRoadMatchIsFalse_Unidirectional() {
+        JsonFeatureCollection featureCollection;
+        try (Response response = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.57839,1.631823&thresholdDistance=2000&requireRoadNameMatch=false").request()
+                .buildGet().invoke()) {
+            assertEquals(200, response.getStatus());
+
+            featureCollection = response.readEntity(JsonFeatureCollection.class);
+        }
+        assertEquals(2, featureCollection.getFeatures().size());
+        Geometry lineString0 = featureCollection.getFeatures().get(0).getGeometry();
+        Geometry lineString1 = featureCollection.getFeatures().get(1).getGeometry();
+
+        // Different start points
+        assertNotEquals(lineString0.getCoordinates()[0], lineString1.getCoordinates()[0]);
+        // Arbitrary - different endpoints
+        assertNotEquals(lineString0.getCoordinates()[lineString0.getCoordinates().length - 1],
+                lineString1.getCoordinates()[lineString1.getCoordinates().length - 1]);
     }
 
     @Test
@@ -158,21 +314,44 @@ public class BufferResourceTest {
     @Test
     public void testCustomQueryMultiplier() {
         try (Response widerResponse = clientTarget(app, "/buffer?profile=my_car&"
-                + "point=42.600114,1.45046&roadName=CG-4&thresholdDistance=2000&queryMultiplier=.2")
+                + "point=42.600114,1.45046&roadName=CG-4&thresholdDistance=2000&queryMultiplier=.2&requireRoadNameMatch=true")
                 .request().buildGet().invoke()) {
             assertEquals(200, widerResponse.getStatus());
         }
 
         JsonNode thinnerJson;
         try (Response thinnerResponse = clientTarget(app, "/buffer?profile=my_car&"
-                + "point=42.600114,1.45046&roadName=CG-4&thresholdDistance=2000").request()
+                + "point=42.600114,1.45046&roadName=CG-4&thresholdDistance=2000&requireRoadNameMatch=true").request()
                 .buildGet().invoke()) {
             assertEquals(500, thinnerResponse.getStatus());
             thinnerJson = thinnerResponse.readEntity(JsonNode.class);
         }
 
         assertTrue(thinnerJson.has("message"), "There should have been an error response");
-        String expected = "Could not find road with that name near the selection.";
+        String expected = "Could not find primary road with that name near the selection.";
+        assertTrue(thinnerJson.get("message").asText().contains(expected),
+                "There should be an error containing " + expected + ", but got: "
+                        + thinnerJson.get("message"));
+    }
+
+    @Test
+    public void testCustomQueryMultiplierWhenRequireRoadMatchIsFalse() {
+        try (Response widerResponse = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.600114,1.45046&roadName=CG-4&thresholdDistance=2000&queryMultiplier=.2&requireRoadNameMatch=false")
+                .request().buildGet().invoke()) {
+            assertEquals(200, widerResponse.getStatus());
+        }
+
+        JsonNode thinnerJson;
+        try (Response thinnerResponse = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.600114,1.45046&roadName=CG-4&thresholdDistance=2000&requireRoadNameMatch=false").request()
+                .buildGet().invoke()) {
+            assertEquals(500, thinnerResponse.getStatus());
+            thinnerJson = thinnerResponse.readEntity(JsonNode.class);
+        }
+
+        assertTrue(thinnerJson.has("message"), "There should have been an error response");
+        String expected = "Could not find primary road with that name near the selection.";
         assertTrue(thinnerJson.get("message").asText().contains(expected),
                 "There should be an error containing " + expected + ", but got: "
                         + thinnerJson.get("message"));
@@ -202,6 +381,61 @@ public class BufferResourceTest {
     }
 
     @Test
+    public void testBidirectionalUpstreamPathWhenRequireRoadMatchIsFalse() {
+        JsonFeatureCollection featureCollection;
+        try (Response response = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.54287,1.471&roadName=CG-4&thresholdDistance=2000&buildUpstream=true&requireRoadNameMatch=false")
+                .request().buildGet().invoke()) {
+            assertEquals(200, response.getStatus());
+
+            featureCollection = response.readEntity(JsonFeatureCollection.class);
+        }
+
+        assertEquals(2, featureCollection.getFeatures().size());
+        Geometry lineString0 = featureCollection.getFeatures().get(0).getGeometry();
+        Geometry lineString1 = featureCollection.getFeatures().get(1).getGeometry();
+
+        // Identical start points (reversed index)
+        assertEquals(lineString0.getCoordinates()[lineString0.getCoordinates().length - 1],
+                lineString1.getCoordinates()[lineString1.getCoordinates().length - 1]);
+
+        // Different endpoints (reversed index)
+        assertNotEquals(lineString0.getCoordinates()[0], lineString1.getCoordinates()[0]);
+    }
+
+    @Test
+    public void testBidirectionalUpstreamPathWhenRequireRoadMatchIsFalse_InvalidName() {
+        JsonFeatureCollection featureCollection;
+        try (Response response = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.54287,1.471&roadName=INVALID&thresholdDistance=2000&buildUpstream=true&requireRoadNameMatch=false")
+                .request().buildGet().invoke()) {
+            assertEquals(200, response.getStatus());
+
+            featureCollection = response.readEntity(JsonFeatureCollection.class);
+        }
+
+        assertEquals(2, featureCollection.getFeatures().size());
+        Geometry lineString0 = featureCollection.getFeatures().get(0).getGeometry();
+        Geometry lineString1 = featureCollection.getFeatures().get(1).getGeometry();
+
+        // Identical start points (reversed index)
+        assertEquals(lineString0.getCoordinates()[lineString0.getCoordinates().length - 1],
+                lineString1.getCoordinates()[lineString1.getCoordinates().length - 1]);
+
+        // Different endpoints (reversed index)
+        assertNotEquals(lineString0.getCoordinates()[0], lineString1.getCoordinates()[0]);
+    }
+
+    @Test
+    public void testBidirectionalUpstreamPathFailsWhenRequireRoadMatchIsTrue_InvalidName() {
+        try (Response response = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.54287,1.471&roadName=INVALID&thresholdDistance=2000&buildUpstream=true&requireRoadNameMatch=true")
+                .request().buildGet().invoke()) {
+            assertEquals(500, response.getStatus());
+        }
+    }
+
+    @Test
     public void testDownstreamAndUpstreamPathAreIdenticalOnPurelyBidirectionalRoad() {
         JsonFeatureCollection downstreamFeatureCollection;
         try (Response downstreamResponse = clientTarget(app, "/buffer?profile=my_car&"
@@ -214,6 +448,51 @@ public class BufferResourceTest {
         JsonFeatureCollection upstreamFeatureCollection;
         try (Response upstreamResponse = clientTarget(app, "/buffer?profile=my_car&"
                 + "point=42.54287,1.471&roadName=CG-4&thresholdDistance=2000&buildUpstream=true")
+                .request().buildGet().invoke()) {
+            assertEquals(200, upstreamResponse.getStatus());
+
+            upstreamFeatureCollection = upstreamResponse.readEntity(JsonFeatureCollection.class);
+        }
+
+        assertEquals(2, upstreamFeatureCollection.getFeatures().size());
+        assertEquals(2, downstreamFeatureCollection.getFeatures().size());
+        Geometry upstreamLineString0 = upstreamFeatureCollection.getFeatures().get(0).getGeometry();
+        Geometry upstreamLineString1 = upstreamFeatureCollection.getFeatures().get(1).getGeometry();
+        Geometry downstreamLineString0 = downstreamFeatureCollection.getFeatures().get(0).getGeometry();
+        Geometry downstreamLineString1 = downstreamFeatureCollection.getFeatures().get(1).getGeometry();
+
+        // Since bidirectional road has an arbitrary flow, downstream-start and
+        // upstream-end should match
+        assertEquals(upstreamLineString1.getCoordinates()[upstreamLineString1.getCoordinates().length - 1],
+                downstreamLineString1.getCoordinates()[0]);
+        assertEquals(upstreamLineString0.getCoordinates()[upstreamLineString0.getCoordinates().length - 1],
+                downstreamLineString0.getCoordinates()[0]);
+
+        // And downstream-end and upstream-start should match
+        assertEquals(upstreamLineString0.getCoordinates()[0],
+                downstreamLineString0.getCoordinates()[downstreamLineString0.getCoordinates().length - 1]);
+        assertEquals(upstreamLineString1.getCoordinates()[0],
+                downstreamLineString1.getCoordinates()[downstreamLineString1.getCoordinates().length - 1]);
+
+        // And origin points should match internally
+        assertEquals(upstreamLineString0.getCoordinates()[upstreamLineString0.getCoordinates().length - 1],
+                upstreamLineString1.getCoordinates()[upstreamLineString1.getCoordinates().length - 1]);
+        assertEquals(downstreamLineString0.getCoordinates()[0], downstreamLineString1.getCoordinates()[0]);
+    }
+
+    @Test
+    public void testDownstreamAndUpstreamPathAreIdenticalOnPurelyBidirectionalRoadWhenRequireRoadMatchIsFalse() {
+        JsonFeatureCollection downstreamFeatureCollection;
+        try (Response downstreamResponse = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.54287,1.471&roadName=CG-4&thresholdDistance=2000&requireRoadNameMatch=false").request()
+                .buildGet().invoke()) {
+            assertEquals(200, downstreamResponse.getStatus());
+            downstreamFeatureCollection = downstreamResponse.readEntity(JsonFeatureCollection.class);
+        }
+
+        JsonFeatureCollection upstreamFeatureCollection;
+        try (Response upstreamResponse = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.54287,1.471&roadName=CG-4&thresholdDistance=2000&buildUpstream=true&requireRoadNameMatch=false")
                 .request().buildGet().invoke()) {
             assertEquals(200, upstreamResponse.getStatus());
 
@@ -286,10 +565,95 @@ public class BufferResourceTest {
     }
 
     @Test
+    public void testDownstreamAndUpstreamPathAreDifferentWithUnidirectionalStartsWhenRequireRoadMatchIsFalse() {
+        JsonFeatureCollection downstreamFeatureCollection;
+        try (Response downstreamResponse = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.57839,1.631823&roadName=CG-2&thresholdDistance=2000&requireRoadNameMatch=false").request()
+                .buildGet().invoke()) {
+            assertEquals(200, downstreamResponse.getStatus());
+            downstreamFeatureCollection = downstreamResponse.readEntity(JsonFeatureCollection.class);
+        }
+
+        JsonFeatureCollection upstreamFeatureCollection;
+        try (Response upstreamResponse = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.57839,1.631823&roadName=CG-2&thresholdDistance=2000&buildUpstream=true&requireRoadNameMatch=false")
+                .request().buildGet().invoke()) {
+            assertEquals(200, upstreamResponse.getStatus());
+
+            upstreamFeatureCollection = upstreamResponse.readEntity(JsonFeatureCollection.class);
+        }
+
+        assertEquals(2, upstreamFeatureCollection.getFeatures().size());
+        assertEquals(2, downstreamFeatureCollection.getFeatures().size());
+        Geometry upstreamLineString0 = upstreamFeatureCollection.getFeatures().get(0).getGeometry();
+        Geometry upstreamLineString1 = upstreamFeatureCollection.getFeatures().get(1).getGeometry();
+        Geometry downstreamLineString0 = downstreamFeatureCollection.getFeatures().get(0).getGeometry();
+        Geometry downstreamLineString1 = downstreamFeatureCollection.getFeatures().get(1).getGeometry();
+
+        // Identical start points despite reversed direction
+        assertEquals(upstreamLineString0.getCoordinates()[upstreamLineString0.getCoordinates().length - 1],
+                downstreamLineString0.getCoordinates()[0]);
+        assertEquals(upstreamLineString1.getCoordinates()[upstreamLineString1.getCoordinates().length - 1],
+                downstreamLineString1.getCoordinates()[0]);
+
+        // Different endpoints
+        assertNotEquals(upstreamLineString0.getCoordinates()[0],
+                downstreamLineString0.getCoordinates()[downstreamLineString0.getCoordinates().length - 1]);
+        assertNotEquals(upstreamLineString1.getCoordinates()[0],
+                downstreamLineString1.getCoordinates()[downstreamLineString1.getCoordinates().length - 1]);
+    }
+
+    @Test
     public void testBidirectionalStartQueryWithSmallerThresholdDistance() {
         JsonFeatureCollection featureCollection;
         try (Response response = clientTarget(app, "/buffer?profile=my_car&"
                 + "point=42.54287,1.471&roadName=CG-4&thresholdDistance=100").request()
+                .buildGet().invoke()) {
+            assertEquals(200, response.getStatus());
+
+            featureCollection = response.readEntity(JsonFeatureCollection.class);
+        }
+
+        assertEquals(2, featureCollection.getFeatures().size());
+        Geometry lineString0 = featureCollection.getFeatures().get(0).getGeometry();
+        Geometry lineString1 = featureCollection.getFeatures().get(1).getGeometry();
+
+        // Identical start points
+        assertEquals(lineString0.getCoordinates()[0], lineString1.getCoordinates()[0]);
+
+        // Different end points
+        assertNotEquals(lineString0.getCoordinates()[lineString0.getCoordinates().length - 1],
+                lineString1.getCoordinates()[lineString1.getCoordinates().length - 1]);
+    }
+
+    @Test
+    public void testBidirectionalStartQueryWithSmallerThresholdDistanceWhenRequireRoadMatchIsFalse() {
+        JsonFeatureCollection featureCollection;
+        try (Response response = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.54287,1.471&roadName=CG-4&thresholdDistance=100&requireRoadNameMatch=false").request()
+                .buildGet().invoke()) {
+            assertEquals(200, response.getStatus());
+
+            featureCollection = response.readEntity(JsonFeatureCollection.class);
+        }
+
+        assertEquals(2, featureCollection.getFeatures().size());
+        Geometry lineString0 = featureCollection.getFeatures().get(0).getGeometry();
+        Geometry lineString1 = featureCollection.getFeatures().get(1).getGeometry();
+
+        // Identical start points
+        assertEquals(lineString0.getCoordinates()[0], lineString1.getCoordinates()[0]);
+
+        // Different end points
+        assertNotEquals(lineString0.getCoordinates()[lineString0.getCoordinates().length - 1],
+                lineString1.getCoordinates()[lineString1.getCoordinates().length - 1]);
+    }
+
+    @Test
+    public void testBidirectionalStartQueryWithSmallerThresholdDistanceAndInvalidNameWhenRequireRoadMatchIsFalse() {
+        JsonFeatureCollection featureCollection;
+        try (Response response = clientTarget(app, "/buffer?profile=my_car&"
+                + "point=42.54287,1.471&roadName=INVALID&thresholdDistance=100&requireRoadNameMatch=false").request()
                 .buildGet().invoke()) {
             assertEquals(200, response.getStatus());
 


### PR DESCRIPTION
Problem:
Currently we are failing to generate TIMs if the road name we provide the buffer endpoint does not match perfectly to the OpenStreetMaps name. This is fairly common as incoming data will use different map datasets that use different naming conventions and because some roads might have multiple names.

Solution:
To allow the user to have the same behavior we have now, I added a parameter "requireRoadNameMatch" that if set to true, will use the provided road name. If this is false, the roadName can be null and the function will query edges in a small bounding box and choose the best edge that either matches the incoming road name the closest or is the closest edge in distance to the incoming point.

Tests:
Attached are the testing documents.
- graphHopperNameTestData.json is a json array of the GH generated paths for each VerMac data object based on different parameters. Each object has a "teaghenNotes" for what testId and test case it's for with a short description of the test and the postman url is under the "teaghenURL" property. 
- The word document summarizes the results and includes definitions and what the tests mean.
- Excel sheet contains the results comparing test cases for each test Id.

To summarize: 
To use the less restrictive name changes here, including a name (while optional) is recommended and will increase the odds to finding the road you actually want without requiring the names to match exactly. If the road is in an area where there is a significant number of edges, it is easy for it to choose the wrong road and return unexpected paths.

[graphHopperNameTestData.json](https://github.com/user-attachments/files/20065170/graphHopperNameTestData.json)
[GH Less Strict Road Name Requirements Test Results.docx](https://github.com/user-attachments/files/20065206/GH.Less.Strict.Road.Name.Requirements.Test.Results.docx)
[Less Strict Road Name Requirements Test Results.xlsx](https://github.com/user-attachments/files/20065207/Less.Strict.Road.Name.Requirements.Test.Results.xlsx)
