### PR TITLE
15458 Ensure that findEdgeByDistAndLCSRoadName uses the best match score

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
@@ -387,14 +387,19 @@ public class BufferResource {
                 }
             }
 
+            // Prioritize the edge with the best match score
+            if ((currentMatchScore > bestMatchScore)) {
+                bestMatchScore = currentMatchScore;
+                nearestEdge = edge;
+            }
             // Calculate the distance to the edge
             PointList pointList = state.fetchWayGeometry(FetchMode.PILLAR_ONLY);
+
             for (GHPoint3D point : pointList) {
                 double dist = DistancePlaneProjection.DIST_PLANE.calcDist(startLat, startLon, point.lat, point.lon);
 
-                // Prioritize the edge with the best match score and the lowest distance
-                if ((currentMatchScore > bestMatchScore) || (currentMatchScore == bestMatchScore && dist < lowestDistance)) {
-                    bestMatchScore = currentMatchScore;
+                // In ties, prioritize the edge with the lowest distance
+                if ((currentMatchScore == bestMatchScore && dist < lowestDistance)) {
                     lowestDistance = dist;
                     nearestEdge = edge;
                 }


### PR DESCRIPTION
In the event that a pointList has zero elements, the findEdgeByDistAndLCSRoadName still needs to choose the best match score.

Details about this bug including testing ideas are here:
https://dev.azure.com/trihydro/CORVUS/_workitems/edit/15458

Note that that test case will return an error to Postman because that test case is ALSO susceptible to Bug 15457.  A breakpoint will show that this test works on the 15458 problem but the Postman result will not show anything useful.
