### PR TITLE
15457 Handle edge equals negative one gracefully

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
@@ -616,6 +616,10 @@ public class BufferResource {
      */
     private PointList computePointAtDistanceThreshold(BufferFeature startFeature, Double thresholdDistance,
                                                       BufferFeature endFeature, Boolean upstreamPath) {
+        if(endFeature.getEdge() < 0)
+        {
+            return new PointList();
+        }
         EdgeIteratorState finalState = graph.getEdgeIteratorState(endFeature.getEdge(), Integer.MIN_VALUE);
         PointList pointList = finalState.fetchWayGeometry(FetchMode.PILLAR_ONLY);
 


### PR DESCRIPTION
Fixes a bug so that an edge = -1 continues execution with an empty PointList rather than throwing.

Details about this bug including testing ideas are here:
https://dev.azure.com/trihydro/CORVUS/_workitems/edit/15457
