### PR TITLE
Bug/15349 Threshold Distance Too Short Fix

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
@@ -312,9 +312,14 @@ public class BufferResource {
             coordinates.add(new Coordinate(point.getLon(), point.getLat()));
         }
 
-        // Add to threshold points
-        for (GHPoint point : featureToThreshold.getPath()) {
-            coordinates.add(new Coordinate(point.getLon(), point.getLat()));
+        // if it is not okay to return startFeature THEN we are using an extrapolated point because all the points in
+        // featureToThreshold are too far. If all the points in featureToThreshold are too far, then we cannot add them!
+        if(isOkayToReturnStartFeature)
+        {
+            // Add to threshold points
+            for (GHPoint point : featureToThreshold.getPath()) {
+                coordinates.add(new Coordinate(point.getLon(), point.getLat()));
+            }
         }
 
         // Add final segment points
@@ -596,8 +601,7 @@ public class BufferResource {
         }
 
         boolean isNodeOriginalNode = true;
-// if it is not okay to return startFeature then we cannot stop looping until currentNode is not the originalNode
-// this comment is not clear.  Reword this comment.  MDO
+        // If the threshold is exceeded, we can stop looping only if it isOkayToReturnStartFeature OR the currentNode is not the originalNode
         while (currentDistance < thresholdDistance || ( !isOkayToReturnStartFeature && isNodeOriginalNode )) {
             EdgeIterator iterator = edgeExplorer.setBaseNode(currentNode);
             List<Integer> potentialEdges = new ArrayList<>();
@@ -757,6 +761,7 @@ public class BufferResource {
             {
                 return pointList;
             }
+            pointList = new PointList();
             PointList tempPointList = finalState.fetchWayGeometry(FetchMode.TOWER_ONLY);
             for (GHPoint3D point : tempPointList) {
                 if (startFeature.getPoint().equals(point))
@@ -789,8 +794,8 @@ public class BufferResource {
         {
             GHPoint3D beyondThresholdPoint = pointList.get(0);
             double totalDist = DistancePlaneProjection.DIST_PLANE.calcDist(startFeature.getPoint().lat, startFeature.getPoint().lon, beyondThresholdPoint.lat, beyondThresholdPoint.lon);
-            double resultLat  = startFeature.getPoint().lat + (beyondThresholdPoint.lat - startFeature.getPoint().lat) * (totalDist/thresholdDistance);
-            double resultLon = startFeature.getPoint().lon + (beyondThresholdPoint.lon - startFeature.getPoint().lon) * (totalDist/thresholdDistance);
+            double resultLat  = startFeature.getPoint().lat + (beyondThresholdPoint.lat - startFeature.getPoint().lat) * (thresholdDistance/totalDist);
+            double resultLon = startFeature.getPoint().lon + (beyondThresholdPoint.lon - startFeature.getPoint().lon) * (thresholdDistance/totalDist);
             GHPoint3D resultPoint = new GHPoint3D(resultLat, resultLon, startFeature.getPoint().ele);
             resultPointList.add(resultPoint);
         }

--- a/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
@@ -295,11 +295,15 @@ public class BufferResource {
      */
     private LineString computeBufferSegment(BufferFeature startFeature, String roadName, Double thresholdDistance,
                                             Boolean upstreamPath, Boolean upstreamStart) {
-        BufferFeature featureToThreshold = computeEdgeAtDistanceThreshold(startFeature, thresholdDistance, roadName,
-                upstreamPath, upstreamStart);
-        PointList finalSegmentToThreshold = computePointAtDistanceThreshold(startFeature, thresholdDistance,
-                featureToThreshold, upstreamPath);
         PointList startingEdgeGeometry = computeWayGeometryOfStartingEdge(startFeature, upstreamStart, thresholdDistance);
+        // If startingEdgeGeometry has only one point then we have to ensure that finalSegmentToThreshold is not empty because
+        // we need to be able to return at least two points.
+        Boolean isOkayToReturnStartFeature = startingEdgeGeometry.size() > 1;
+        BufferFeature featureToThreshold = computeEdgeAtDistanceThreshold(startFeature, thresholdDistance, roadName,
+                upstreamPath, upstreamStart, isOkayToReturnStartFeature);
+        PointList finalSegmentToThreshold = computePointAtDistanceThreshold(startFeature, thresholdDistance,
+                featureToThreshold, upstreamPath, isOkayToReturnStartFeature);
+
 
         List<Coordinate> coordinates = new ArrayList<>();
 
@@ -374,7 +378,7 @@ public class BufferResource {
      * @param isPillarOnly determines if pillar or tower points are attempted. Always check pillar points first
      *                     but if no pillar points are found, then check tower points. My understanding is that
      *                     there will always be tower points. (docs/core/low-level-api.md#what-are-pillar-and-tower-nodes)
-            * @return closest point along road
+     * @return closest point along road
      */
     private BufferFeature computeStartFeature(List<Integer> edgeList, Double startLat, Double startLon, Boolean isPillarOnly) {
         double lowestDistance = Double.MAX_VALUE;
@@ -556,10 +560,16 @@ public class BufferResource {
      *                          road's flow
      * @param upstreamStart     initial 'launch' direction - used only for a
      *                          bidirectional start
+     * @param isOkayToReturnStartFeature    determines if it is acceptable to return startFeature.
+     *                                      If it is not acceptable to return startFeature then
+     *                                      it may be necessary to exceed thresholdDistance to find
+     *                                      a BufferFeature.
+     *
      * @return buffer feature at specified distance away from start
      */
     private BufferFeature computeEdgeAtDistanceThreshold(final BufferFeature startFeature, Double thresholdDistance,
-                                                         String roadName, Boolean upstreamPath, Boolean upstreamStart) {
+                                                         String roadName, Boolean upstreamPath, Boolean upstreamStart,
+                                                         Boolean isOkayToReturnStartFeature) {
         List<Integer> usedEdges = new ArrayList<>() {
             {
                 add(startFeature.getEdge());
@@ -572,19 +582,23 @@ public class BufferResource {
 
         // Check starting edge
         double currentDistance = DistancePlaneProjection.DIST_PLANE.calcDist(
-            startFeature.getPoint().getLat(), startFeature.getPoint().getLon(),
-            nodeAccess.getLat(currentNode), nodeAccess.getLon(currentNode));
+                startFeature.getPoint().getLat(), startFeature.getPoint().getLon(),
+                nodeAccess.getLat(currentNode), nodeAccess.getLon(currentNode));
         double previousDistance = 0.0;
         Integer currentEdge = -1;
         // Create previous values to use in case we don't meet the threshold
         Integer previousEdge = currentEdge;
+        int originalNode = currentNode;
         int previousNode = currentNode;
 
-        if (currentDistance >= thresholdDistance) {
+        if (currentDistance >= thresholdDistance && isOkayToReturnStartFeature) {
             return startFeature;
         }
 
-        while (currentDistance < thresholdDistance) {
+        boolean isNodeOriginalNode = true;
+// if it is not okay to return startFeature then we cannot stop looping until currentNode is not the originalNode
+// this comment is not clear.  Reword this comment.  MDO
+        while (currentDistance < thresholdDistance || ( !isOkayToReturnStartFeature && isNodeOriginalNode )) {
             EdgeIterator iterator = edgeExplorer.setBaseNode(currentNode);
             List<Integer> potentialEdges = new ArrayList<>();
             List<Integer> potentialRoundaboutEdges = new ArrayList<>();
@@ -684,7 +698,8 @@ public class BufferResource {
                     nodeAccess.getLon(currentNode), nodeAccess.getLat(otherNode), nodeAccess.getLon(otherNode));
 
             // Break before moving to next node in case hitting the threshold
-            if (currentDistance >= thresholdDistance) {
+            isNodeOriginalNode = currentNode == originalNode;
+            if (currentDistance >= thresholdDistance && ( isOkayToReturnStartFeature || !isNodeOriginalNode )) {
                 break;
             }
 
@@ -725,7 +740,7 @@ public class BufferResource {
      * @return PointList to threshold along given edge of end feature
      */
     private PointList computePointAtDistanceThreshold(BufferFeature startFeature, Double thresholdDistance,
-                                                      BufferFeature endFeature, Boolean upstreamPath) {
+                                                      BufferFeature endFeature, Boolean upstreamPath, Boolean isOkayToReturnZeroPoints) {
         if(endFeature.getEdge() < 0)
         {
             return new PointList();
@@ -738,7 +753,10 @@ public class BufferResource {
         // When this happens, filtering by FetchMode.PILLAR_ONLY will return an empty
         // PointList.
         if (pointList.isEmpty()) {
-            pointList = new PointList();
+            if(isOkayToReturnZeroPoints)
+            {
+                return pointList;
+            }
             PointList tempPointList = finalState.fetchWayGeometry(FetchMode.TOWER_ONLY);
             for (GHPoint3D point : tempPointList) {
                 if (startFeature.getPoint().equals(point))
@@ -763,7 +781,20 @@ public class BufferResource {
         Double currentDistance = endFeature.getDistance();
         GHPoint3D previousPoint = pointList.get(0);
 
-        return computePathListWithinThreshold(thresholdDistance, pointList, currentDistance, previousPoint);
+        PointList resultPointList = computePathListWithinThreshold(thresholdDistance, pointList, currentDistance, previousPoint);
+
+        // If we must return a point and we do not have one then we need to create a point.  We can create a point because the
+        // line segment connecting any two consecutive points of a path necessarily lies entirely on the road.
+        if(!isOkayToReturnZeroPoints && resultPointList.isEmpty())
+        {
+            GHPoint3D beyondThresholdPoint = pointList.get(0);
+            double totalDist = DistancePlaneProjection.DIST_PLANE.calcDist(startFeature.getPoint().lat, startFeature.getPoint().lon, beyondThresholdPoint.lat, beyondThresholdPoint.lon);
+            double resultLat  = startFeature.getPoint().lat + (beyondThresholdPoint.lat - startFeature.getPoint().lat) * (totalDist/thresholdDistance);
+            double resultLon = startFeature.getPoint().lon + (beyondThresholdPoint.lon - startFeature.getPoint().lon) * (totalDist/thresholdDistance);
+            GHPoint3D resultPoint = new GHPoint3D(resultLat, resultLon, startFeature.getPoint().ele);
+            resultPointList.add(resultPoint);
+        }
+        return resultPointList;
     }
 
     /**

--- a/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
@@ -304,7 +304,6 @@ public class BufferResource {
         PointList finalSegmentToThreshold = computePointAtDistanceThreshold(startFeature, thresholdDistance,
                 featureToThreshold, upstreamPath, isOkayToReturnStartFeature);
 
-
         List<Coordinate> coordinates = new ArrayList<>();
 
         // Add start feature point

--- a/web/src/test/java/com/graphhopper/application/resources/BufferResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/BufferResourceTest.java
@@ -667,20 +667,23 @@ public class BufferResourceTest {
     }
 
     @Test
-    public void testBidirectionalStartQueryWithTooSmallThresholdDistance() {
-        JsonNode json;
-        try (Response response = clientTarget(app, "/buffer?profile=my_car&"
-                + "point=42.54287,1.471&roadName=CG-4&thresholdDistance=50").request()
+    public void testSucceedsWhenStartingEdgeGeometryHasOnePoint() {
+        JsonFeatureCollection featureCollection;
+        try (Response response = clientTarget(app, "/buffer?profile=my_car&point=42.506380,1.528551&roadName=Bonaventura-4&thresholdDistance=50").request()
                 .buildGet().invoke()) {
 
-            assertEquals(500, response.getStatus());
-            json = response.readEntity(JsonNode.class);
+            assertEquals(200, response.getStatus());
+            featureCollection = response.readEntity(JsonFeatureCollection.class);
         }
-        assertTrue(json.has("message"), "There should have been an error response");
-        String expected = "Threshold distance is too short to construct a valid path.";
-        assertTrue(json.get("message").asText().contains(expected),
-                "There should be an error containing " + expected + ", but got: "
-                        + json.get("message"));
+        assertEquals(2, featureCollection.getFeatures().size());
+        Geometry lineString0 = featureCollection.getFeatures().get(0).getGeometry();
+        Geometry lineString1 = featureCollection.getFeatures().get(1).getGeometry();
+
+        // The lineString that only had one point in the startingEdgeGeometry should result in exactly two points.
+        assertEquals(2, lineString0.getCoordinates().length);
+
+        // The other lineString have at least 2 points.
+        assertTrue(lineString1.getCoordinates().length >= 2, "The second lineString should have at least 2 points");
     }
 
     @Test


### PR DESCRIPTION
Problem:
With the current implementation, it's possible that the points of the edge (either the base or adjacent point) from the starting feature are a larger distance away than the provided threshold distance. When this happens, we return the starting feature as the point and this results in the "Threshold distance is too short" Exception being thrown shortly after. It's a rare problem but can happen on really short roads or if the edge is really long.

Solution:
If we encounter a starting edge geometry that only has one point, we can handle this case now by extrapolating a point to ensure that the final segment to threshold pointList contains at least 2 points.