### PR TITLE
Prefer named roads and fix path generation at road-name boundaries

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
@@ -25,6 +25,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -45,6 +46,7 @@ public class BufferResource {
 
     //region Constants, Enums and Records
     private static final double PROXIMITY_THRESHOLD_METERS = 6.096; // 20 feet
+    private static final double NAMED_EDGE_PREFERENCE_TOLERANCE_METERS = 0.3048; // 1 foot
     private static final double INITIAL_SEARCH_RADIUS_DEGREES = 0.0001; // Roughly 11 meters
 
     /**
@@ -62,6 +64,15 @@ public class BufferResource {
             preferredEdges = preferredEdges != null ? preferredEdges : Collections.emptyList();
         }
     }
+
+    /**
+     * Holds the result of a closest-edge lookup.
+     *
+     * @param edgeId   the ID of the closest edge, or {@code null} if no candidate edges were provided
+     * @param distance the straight-line distance in meters from the query point to the closest edge;
+     *                 {@link Double#MAX_VALUE} when {@code edgeId} is {@code null}
+     */
+    public record ClosestEdgeResult(Integer edgeId, double distance) {}
 
     //endregion
     //region Constructor
@@ -195,10 +206,7 @@ public class BufferResource {
         });
 
         // Find the closest edge within proximity
-        List<Integer> edgesWithinProximity = new ArrayList<>();
-        edgesWithinProximity.addAll(namedEdges);
-        edgesWithinProximity.addAll(unnamedEdges);
-        Integer closestEdge = findClosestEdgeByDistance(edgesWithinProximity, point.get().lat, point.get().lon);
+        Integer closestEdge = selectClosestEdgePreferringNamed(namedEdges, unnamedEdges, point.get().lat, point.get().lon);
 
         if (closestEdge != null) {
             EdgeIteratorState state = graph.getEdgeIteratorState(closestEdge, Integer.MIN_VALUE);
@@ -378,9 +386,16 @@ public class BufferResource {
         {
             featureToThreshold = buildPathToThresholdDistance(startFeature, thresholdDistance, roadName, upstreamPath, upstreamStart);
             for (GHPoint point : featureToThreshold.getPath()) {
-                coordinates.add(new Coordinate(point.getLon(), point.getLat()));
+                Coordinate coordinate = new Coordinate(point.getLon(), point.getLat());
+                if (!coordinates.contains(coordinate)) {
+                    coordinates.add(coordinate);
+                }
             }
         }
+
+        // If only the start point was added, force final segment generation directly from start to threshold.
+        if (coordinates.size() == 1)
+            startEdgeIsWithinThreshold = false;
 
         // Get geometry of final segment to the threshold point
         PointList finalSegmentToThreshold = computeFinalSegmentToThreshold(startFeature, thresholdDistance, featureToThreshold, startEdgeIsWithinThreshold, upstreamPath);
@@ -860,14 +875,48 @@ public class BufferResource {
     }
 
     /**
+     * Selects the closest edge to the given point from two candidate lists — named and unnamed edges —
+     * preferring the named edge when it is closer or within {@code NAMED_EDGE_PREFERENCE_TOLERANCE_METERS}
+     * of the closest unnamed edge. Only falls back to the unnamed edge when the named edge is further away
+     * by more than that tolerance.
+     *
+     * <p>Selection rules:</p>
+     * <ul>
+     *   <li>Named only: returns the closest named edge.</li>
+     *   <li>Unnamed only: returns the closest unnamed edge.</li>
+     *   <li>Both present: returns the named edge if its distance is less than or equal to
+     *       {@code unnamedDistance + NAMED_EDGE_PREFERENCE_TOLERANCE_METERS}; otherwise the unnamed edge.</li>
+     * </ul>
+     *e
+     * @param namedEdges   list of named edge IDs to search
+     * @param unnamedEdges list of unnamed edge IDs to search
+     * @param lat          latitude of the target point
+     * @param lon          longitude of the target point
+     * @return the selected edge ID, or null if both lists are empty
+     */
+    private Integer selectClosestEdgePreferringNamed(List<Integer> namedEdges, List<Integer> unnamedEdges, double lat, double lon) {
+        ClosestEdgeResult closestNamed = findClosestEdgeByDistance(namedEdges, lat, lon);
+        ClosestEdgeResult closestUnnamed = findClosestEdgeByDistance(unnamedEdges, lat, lon);
+
+        if (closestNamed.edgeId() == null) return closestUnnamed.edgeId();
+        if (closestUnnamed.edgeId() == null) return closestNamed.edgeId();
+
+        // Prefer named when it is closer, or only slightly farther than the unnamed edge
+        boolean namedIsCloserOrWithinForgiveness =
+                closestNamed.distance() <= closestUnnamed.distance() + NAMED_EDGE_PREFERENCE_TOLERANCE_METERS;
+
+        return namedIsCloserOrWithinForgiveness ? closestNamed.edgeId() : closestUnnamed.edgeId();
+    }
+
+    /**
      * Finds the closest edge by distance from a list of edges.
      *
      * @param edges list of edge IDs to search
      * @param lat latitude of the target point
      * @param lon longitude of the target point
-     * @return closest edge ID, or null if no edges found
+     * @return closest edge ID with the distance, or null if no edges found
      */
-    private Integer findClosestEdgeByDistance(List<Integer> edges, double lat, double lon) {
+    private ClosestEdgeResult findClosestEdgeByDistance(List<Integer> edges, double lat, double lon) {
         double minDistance = Double.MAX_VALUE;
         Integer closestEdge = null;
 
@@ -879,7 +928,7 @@ public class BufferResource {
             }
         }
 
-        return closestEdge;
+        return new ClosestEdgeResult(closestEdge, minDistance);
     }
 
     //endregion


### PR DESCRIPTION
# Summary
This PR addresses three related bugs in BufferResource.java that caused incorrect road selection and degenerate path generation.

Bug: [Devops Link](https://dev.azure.com/trihydro/CORVUS/_workitems/edit/18028)

Note:
- Incoming road name is `SE 3rd St`. CARS translator converts to `3rd Street`
- Coordinates: `41.729628, -93.600163`
- Direction: `east`

# Solution
## Bug 1: Unnamed road selected over a nearby named road
When a query point was located very close to both a named and an unnamed road edge, the original code would select the unnamed edge as the "closest" without any preference for named roads. This produced buffers traced along an anonymous road segment rather than the intended named street.

**Fix:** A new selectClosestEdgePreferringNamed() helper compares the closest named edge against the closest unnamed edge. If the named edge is closer, or within a 1-foot (0.3048 m) tolerance of the unnamed edge, the named edge wins. Only if the unnamed edge is more than 1 foot closer does the unnamed-road fallback path activate. 

## Bug 2: buildPathToThresholdDistance returns only the start point
Fixing Bug 1 exposed a scenario where buildPathToThresholdDistance returned a BufferFeature that was identical to the start feature — containing only a single point and no traversed path.

**Root cause:** The start feature's point is the base node of the start edge, so the initial currentDistance is 0. On the first loop iteration, the next edge is skipped because it belongs to a different road name (e.g. "SouthEast 3rd Street" transitions to "SouthWest 3rd Street"). Since only one node was ever visited and its road name didn't match, no path points were appended and the method returned the initial node which happened to be the original start feature.

**Fix**: In buildCompletePath, after buildPathToThresholdDistance returns, the coordinates list is checked for duplicates before adding coordinates. We already did this for the last segment of the path generation.

## Bug 3: computeFinalSegmentToThreshold returned no points despite only the start point being in our path so far.
When the path from start to threshold contained no new intermediate nodes (as surfaced by Bug 2), the computeFinalSegmentToThreshold method assumed that it could return an empty PointList which left fewer than 2 points in the final path and triggered the "Threshold distance is too short" exception.

**Fix**: the startEdgeIsWithinThreshold is checked after the buildPathToThresholdDistance is called and before the computeFinalSegmentToThreshold so that it knows if it can return an empty point list based on whether to featureToThreshold call successfully found coordinates or not.

<img width="833" height="739" alt="image" src="https://github.com/user-attachments/assets/959f9b1e-e59a-4873-af90-1f58590b57fd" />
