### PR TITLE
Stricter Edge Selection Road Name Match

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
@@ -345,7 +345,7 @@ public class BufferResource {
             EdgeIteratorState state = graph.getEdgeIteratorState(edgeId, Integer.MIN_VALUE);
             List<String> queryRoadNames = getAllRouteNamesFromEdge(state);
 
-            if ((roadName != null && queryRoadNames.stream().anyMatch(x -> x.contains(roadName)))
+            if ((roadName != null && queryRoadNames.stream().anyMatch(x -> x.equals(roadName)))
                     || (roadName == null && !queryRoadNames.stream().allMatch(String::isEmpty))) {
                 filteredEdgesInBbox.add(edgeId);
             }
@@ -560,7 +560,7 @@ public class BufferResource {
 
                     // Temp has proper road name, isn't part of a roundabout, and bidirectional.
                     // Higher priority escape.
-                    if (roadName != null && roadNames.stream().anyMatch(x -> x.contains(roadName))
+                    if (roadName != null && roadNames.stream().anyMatch(x -> x.equals(roadName))
                             && !tempState.get(this.roundaboutAccessEnc)
                             && isBidirectional(tempState)) {
                         currentEdge = tempEdge;
@@ -569,13 +569,13 @@ public class BufferResource {
                     }
 
                     // Temp has proper road name and isn't part of a roundabout. Lower priority escape.
-                    else if (roadName != null && roadNames.stream().anyMatch(x -> x.contains(roadName))
+                    else if (roadName != null && roadNames.stream().anyMatch(x -> x.equals(roadName))
                             && !tempState.get(this.roundaboutAccessEnc)) {
                         potentialEdges.add(tempEdge);
                     }
 
                     // Temp has proper road name and is part of a roundabout. Higher entry priority.
-                    else if (roadName != null && roadNames.stream().anyMatch(x -> x.contains(roadName))
+                    else if (roadName != null && roadNames.stream().anyMatch(x -> x.equals(roadName))
                             && tempState.get(this.roundaboutAccessEnc)) {
                         potentialRoundaboutEdges.add(tempEdge);
                     }


### PR DESCRIPTION
Summary
The BufferResource was generating a path that went down South Camp Butler Road instead of staying on Camp Butler Road. 
<img width="685" height="731" alt="image" src="https://github.com/user-attachments/assets/00b94855-c609-4d7d-8ebc-d351df856ffb" />

Solution
When we were getting road names from external systems, we had to be more relaxed on road name matching. We recently improved our logic by using the road name of the first edge that we find so that we're consistently using OSM's road names and we don't need to be as relaxed on road name matching. Changed `.Contains(roadName)` to `.Equals(roadName)`
<img width="943" height="518" alt="image" src="https://github.com/user-attachments/assets/cb8ca325-04ee-46bd-ac8c-6b2100acb0df" />

Testing
Regression tested