### PR TITLE
collect all unnamed edges and find straightest edge

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/BufferResource.java
@@ -588,14 +588,9 @@ public class BufferResource {
                         boolean matchesPreviousEdgeName = (currentIsBlank && previousIsBlank)
                                 || (currentEdgeRoadName != null && currentEdgeRoadName.equals(previousRoadName));
 
-                        if (matchesPreviousEdgeName && !currentIsBlank) {
-                            currentEdge = tempEdge;
-                            usedEdges.add(tempEdge);
-                            break;
-                        }
-
-                        // Collect both named and unnamed edges for angle-based selection when continuing from an unnamed road.
-                        if (previousIsBlank) {
+                        // Collect all qualifying unnamed edges that either match the previous edge name or are the first unnamed edge after a named edge.
+                        // After the loop we will select the straightest edge from this list to continue the path.
+                        if ((matchesPreviousEdgeName && !currentIsBlank) || previousIsBlank) {
                             candidateEdgesFromUnnamedRoad.add(tempEdge);
                         }
                     }

--- a/web/src/test/java/com/graphhopper/application/resources/BufferResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/BufferResourceTest.java
@@ -398,6 +398,24 @@ public class BufferResourceTest {
     }
 
     @Test
+    public void testUnidirectionalUpstreamPathWithUnnamedEdgeStart() {
+        JsonFeatureCollection featureCollection;
+        try (Response response = clientTarget(app, "/buffer?queryMultiplier=.000075&"
+                + "point=42.531666,1.520129&roadName=CG-3&thresholdDistance=200&buildUpstream=true")
+                .request().buildGet().invoke()) {
+            assertEquals(200, response.getStatus());
+
+            featureCollection = response.readEntity(JsonFeatureCollection.class);
+        }
+
+        // Expect a single feature collection for unidirectional
+        assertEquals(1, featureCollection.getFeatures().size());
+        // Expect a line string with coordinates to have been built
+        Geometry lineString0 = featureCollection.getFeatures().get(0).getGeometry();
+        assertNotEquals(0, lineString0.getCoordinates().length);
+    }
+
+    @Test
     public void testBidirectionalUpstreamPathWhenRequireRoadMatchIsFalse_InvalidName() {
         JsonFeatureCollection featureCollection;
         try (Response response = clientTarget(app, "/buffer?profile=my_car&"


### PR DESCRIPTION
## Description

We have a bug on an IL highway where if an upstream TIM starts on a ramp (unnamed edge) the rest of the path is not getting generated correctly:
<img width="788" height="689" alt="Screenshot 2026-07-06 at 12 51 29 PM" src="https://github.com/user-attachments/assets/7833c89d-7b7d-4d53-b4d0-bb78d6b0c28f" />

## Solution 

We can mitigate this by collecting all unnamed edges and choosing the straightest edge. Results: 
<img width="614" height="744" alt="Screenshot 2026-07-06 at 12 51 37 PM" src="https://github.com/user-attachments/assets/d285076c-ebfc-410e-87af-7bea9a6028fe" />

## Testing
A unit test has been added that starts an upstream edge on an unnamed road and verifies that a single feature collection is generated. I didn't see any other unit tests hit this code yet so this is a basic start. Path drawn from unit test (starting at the bottom):
<img width="590" height="699" alt="Screenshot 2026-07-06 at 12 51 43 PM" src="https://github.com/user-attachments/assets/8e41707d-64b8-479a-be34-a7295e846941" />


